### PR TITLE
Update `created` field type to integer.

### DIFF
--- a/send_message.go
+++ b/send_message.go
@@ -91,7 +91,7 @@ type LayoutMessage struct {
 
 type Message struct {
 	ID      string `json:"id"`
-	Created string `json:"created"`
+	Created int `json:"created"`
 	Text    string `json:"text,omitempty"`
 }
 

--- a/send_message.go
+++ b/send_message.go
@@ -91,7 +91,7 @@ type LayoutMessage struct {
 
 type Message struct {
 	ID      string `json:"id"`
-	Created int `json:"created"`
+	Created int    `json:"created"`
 	Text    string `json:"text,omitempty"`
 }
 


### PR DESCRIPTION
The `created` field in the send message response has been updated to
an integer rather than the current string, meaning unmarshalling the response
fails.

Unfortunately the official docs don't seem to reflect this
([here](https://docs.vestaboard.com/methods)) but it is reproducible repeatedly
here.

I didn't add tests for this since it would require building a mock that wasn't
in place currently. I can do this if you'd like!
